### PR TITLE
Added support for multiple line endings in a single file

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ var request = require('request');
 // All of these arguments are optional.
 var options = {
 	delimiter : '\t', // default is ,
-	endLine : '\n', // default is \n,
+	endLine : '\n', // default is \n; an array of characters can be used to support multiple line endings ['\n', '\r'],,
 	columns : ['columnName1', 'columnName2'] // by default read the first line and use values found as columns 
 	escapeChar : '"', // default is an empty string
 	enclosedChar : '"' // default is an empty string

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ var request = require('request');
 // All of these arguments are optional.
 var options = {
 	delimiter : '\t', // default is ,
-	endLine : '\n', // default is \n; an array of characters can be used to support multiple line endings ['\n', '\r'],,
+	endLine : '\n', // default is \n; an array of characters can be used to support multiple line endings ['\n', '\r'],
 	columns : ['columnName1', 'columnName2'] // by default read the first line and use values found as columns 
 	escapeChar : '"', // default is an empty string
 	enclosedChar : '"' // default is an empty string

--- a/examples/multi_line_endings.js
+++ b/examples/multi_line_endings.js
@@ -1,0 +1,19 @@
+/**
+ * Modules dependencies
+ */
+
+var csv = require('./../'),
+	request = require('request');
+
+// Parse csv product feed from Zuneta
+var options = {
+        endLine : ['\n', '\r']
+}
+request('http://www.zuneta.com/feeds/productBrands.txt')
+	.pipe(csv.createStream(options))
+	.on('data',function(data){
+		console.log(data);
+	})
+	.on('column',function(key,value){
+		//console.log('#' + key + '=' + value);
+	})

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -18,6 +18,19 @@ function Parser(options){
 	EventEmitter.call(this);
 	this.delimiter = options ? options.delimiter || ',' : ',';
 	this.endLine = options ? options.endLine || '\n' : '\n';
+	
+	//a bit of input validation
+	if(!Array.isArray(this.endLine)){
+	  
+	  //make an array to be consistent
+	  this.endLine = [this.endLine];
+	} else if(this.endLine.length === 0) {
+	  
+	  //its an array, but its empty reset the default
+	  this.endLine = ['\n']
+	  
+	}	  	
+	
 	this.enclosedChar = options ? options.enclosedChar || '' : '';
 	this.escapeChar = options ? options.escapeChar || '' : '';
 
@@ -66,8 +79,8 @@ Parser.prototype.parse = function(s){
 					}
 					this._text = '';
 					this._currentColumn++;
-				}
-			}else if(this.endLine === c){ //LF
+				}				
+			}else if(this.endLine.some(function(end){ return end === c })){  //allow ability to support multiple endLine delimiters.  Useful if a single script could be fed a csv with CR or LF			  
 				if(this._enclosing){
 					this._text = this._text + c;
 				}else{

--- a/test/parser-test.js
+++ b/test/parser-test.js
@@ -22,12 +22,12 @@ describe('Parser',function(){
 			assert.equal(parser.delimiter,'~');
 		});
 		it('should use \\n to notice the end of line by default',function(){
-			var parser = new Parser();
-			assert.equal(parser.endLine,'\n');
-		});
+			var parser = new Parser();			
+			assert.equal(parser.endLine.pop(),'\n');
+		});		
 		it('should use \\r  to notice the end of a line if specified',function(){
 			var parser = new Parser({endLine : '\r'});
-			assert.equal(parser.endLine,'\r');
+			assert.equal(parser.endLine.pop(),'\r');
 		});
 		it('should use no default columns by default',function(){
 			var parser = new Parser();
@@ -190,6 +190,32 @@ describe('Parser',function(){
 			});
 			parser.parse(csvText);
 			parser.end();
+		});
+		it('should emit all `data` events with the right data considering the use of the enclosed character array', function(done){
+		  
+		  //mixed line endings probably not going to be seen in a file, but demonstrates feature
+		  var csvText = '"id","title","description"\n'
+		                + '"1","promothee,1","spaceship\n1"\r'
+		                + '"2","asgards,2","alien\n2"\n';
+		  
+		  var parser = new Parser({
+		    enclosedChar : '"',
+        delimiter : ',',
+        endLine : ['\n', '\r']
+		  });
+		  var length = 0;
+		  parser.on('data',function(data){
+        assert.isObject(data);
+        if(length === 0) assert.deepEqual(data, {id : '1', title : 'promothee,1', description : 'spaceship\n1'});
+        if(length === 1) assert.deepEqual(data, {id : '2', title : 'asgards,2', description : 'alien\n2'});
+        length++;
+      });
+      parser.on('end',function(){
+        assert.equal(length,2);
+        done();
+      });
+      parser.parse(csvText);
+      parser.end();		  
 		});
 		it('should emit all `data` events with the right data considering the escape character "',function(done){
 			var csvText = '"id","title","description"\n'


### PR DESCRIPTION
Hey!

I had a use case where a user would upload a csv file and then I'd parse it converting it to JSON.  Since a user would submit a windows csv ( \r line endings ) or a *nix csv ( \n line endings), it was necessary for me to allow an or case when determining the value of this.endLine. 

Therefore I introduced a bit of code to allow this.  endLine can now be an array.  To maintain backward compatibility, I did not mandate an array to be passed.  I found this useful and thought perhaps it should be included.

Cheers
