### PR TITLE
change default value of _encoding

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ function CSVStream(options){
 
 	// Buffer
 	this._buffer = new Buffer(0);
-	this._encoding = '';
+	this._encoding = undefined;
 
 	// CSV parser
 	this._parser = new Parser(options);


### PR DESCRIPTION
In some scenarios, our code fails with:
```
TypeError: Unknown encoding:                                                                                                                                                                                                                  
    at stringSlice (buffer.js:593:9)                                                                                                                                                                                                          
    at Buffer.toString (buffer.js:629:10)                                                                                                                                                                                                     
    at CSVStream.write (node_modules/csv-stream/index.js:59:34)                                                                                                                                         
    at Gunzip.ondata (_stream_readable.js:642:20)                                                                                                                                                                                             
    at emitOne (events.js:115:13)                                                                                                                                                                                                             
    at Gunzip.emit (events.js:210:7)                                                                                                                                                                                                          
    at addChunk (_stream_readable.js:266:12)                                                                                                                                                                                                  
    at readableAddChunk (_stream_readable.js:253:11)                                                                                                                                                                                          
    at Gunzip.Readable.push (_stream_readable.js:211:10)                                                                                                                                                                                      
    at Gunzip.Transform.push (_stream_transform.js:147:32)      
```

This fixes that.
