### PR TITLE
fix: Breaking stream due to default encoding NodeJS 8.x update Buffer…

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ function CSVStream(options){
 
 	// Buffer
 	this._buffer = new Buffer(0);
-	this._encoding = '';
+	this._encoding = undefined; // Encoding needs to be undefined for Buffer.toString method
 
 	// CSV parser
 	this._parser = new Parser(options);


### PR DESCRIPTION
NodeJS 8.x release `Buffer.toString` now have strict checking for encoding

See https://github.com/nodejs/node/pull/11120